### PR TITLE
Pr.opencv.3.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required(VERSION 3.0)
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.15.16.tar.gz"
-  SHA1 "ca1b3388940bd2ca4452b62a407e6aca743d0ea2"
+  URL "https://github.com/ruslo/hunter/archive/v0.19.161.tar.gz"
+  SHA1 "9af482b6a54875bbbb221274f7290324dff29919"
   )
 
-project(cvmatio VERSION 1.0.18)
+project(cvmatio VERSION 1.0.19)
 
 # -----------------------------------------------
 # USER-DEFINED VARIABLES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ HunterGate(
   SHA1 "9af482b6a54875bbbb221274f7290324dff29919"
   )
 
-project(cvmatio VERSION 1.0.19)
+project(cvmatio VERSION 1.0.28)
 
 # -----------------------------------------------
 # USER-DEFINED VARIABLES

--- a/src/MatlabIO.cpp
+++ b/src/MatlabIO.cpp
@@ -51,7 +51,7 @@ using namespace cv;
 
 // This is a place holder until a cmake try_compile() can be added based
 // on the OpenCV dependency
-#if (CV_VERSION_MAJOR > 3) && (CV_VERSION_MINOR > 3) && (CV_VERSION_REVISION >= 0)
+#if ((CV_VERSION_MAJOR >= 3) && (CV_VERSION_MINOR >= 3)) || (CV_VERSION_MAJOR >= 4)
 #  define CVMATIO_HAS_OPENCV_INT64 0
 #else
 #  define CVMATIO_HAS_OPENCV_INT64 1
@@ -412,22 +412,13 @@ MatlabIOContainer MatlabIO::constructMatrix(vector<char>& name, vector<uint32_t>
 			vec_real = convertPrimitiveType<uint32_t, T>(real);
 			vec_imag = convertPrimitiveType<uint32_t, T>(imag);
 			break;
-
 		case MAT_INT64:
-#if CVMATIO_HAS_OPENCV_INT64
 			vec_real = convertPrimitiveType<int64_t, T>(real);
 			vec_imag = convertPrimitiveType<int64_t, T>(imag);
-#else
-            CV_Assert(false);
-#endif
 			break;
 		case MAT_UINT64:
-#if CVMATIO_HAS_OPENCV_INT64
 			vec_real = convertPrimitiveType<uint64_t, T>(real);
 			vec_imag = convertPrimitiveType<uint64_t, T>(imag);
-#else
-            CV_Assert(false);
-#endif
 			break;
 		case MAT_FLOAT:
 			vec_real = convertPrimitiveType<float, T>(real);
@@ -571,14 +562,14 @@ MatlabIOContainer MatlabIO::collateMatrixFields(uint32_t, uint32_t, vector<char>
 #if CVMATIO_HAS_OPENCV_INT64
             variable = constructMatrix<int64_t>(name, dims, real, imag, real_type);
 #else
-            CV_Assert(false);
+            CV_Assert(false); // alert user that file can't be parsed
 #endif
             break;
         case MAT_UINT64_CLASS:
 #if CVMATIO_HAS_OPENCV_INT64
             variable = constructMatrix<uint64_t>(name, dims, real, imag, real_type);
 #else
-            CV_Assert(false);
+            CV_Assert(false); // alert user that file can't be parsed
 #endif
             break;
         case MAT_CHAR_CLASS:      variable = constructString(name, dims, real); break;

--- a/src/MatlabIO.cpp
+++ b/src/MatlabIO.cpp
@@ -49,6 +49,14 @@
 using namespace std;
 using namespace cv;
 
+// This is a place holder until a cmake try_compile() can be added based
+// on the OpenCV dependency
+#if (CV_VERSION_MAJOR > 3) && (CV_VERSION_MINOR > 3) && (CV_VERSION_REVISION >= 0)
+#  define CVMATIO_HAS_OPENCV_INT64 0
+#else
+#  define CVMATIO_HAS_OPENCV_INT64 1
+#endif
+
 /*! @brief Open a filestream for reading or writing
  *
  * @param filename the full name and filepath of the file
@@ -404,13 +412,22 @@ MatlabIOContainer MatlabIO::constructMatrix(vector<char>& name, vector<uint32_t>
 			vec_real = convertPrimitiveType<uint32_t, T>(real);
 			vec_imag = convertPrimitiveType<uint32_t, T>(imag);
 			break;
+
 		case MAT_INT64:
+#if CVMATIO_HAS_OPENCV_INT64
 			vec_real = convertPrimitiveType<int64_t, T>(real);
 			vec_imag = convertPrimitiveType<int64_t, T>(imag);
+#else
+            CV_Assert(false);
+#endif
 			break;
 		case MAT_UINT64:
+#if CVMATIO_HAS_OPENCV_INT64
 			vec_real = convertPrimitiveType<uint64_t, T>(real);
 			vec_imag = convertPrimitiveType<uint64_t, T>(imag);
+#else
+            CV_Assert(false);
+#endif
 			break;
 		case MAT_FLOAT:
 			vec_real = convertPrimitiveType<float, T>(real);
@@ -550,8 +567,20 @@ MatlabIOContainer MatlabIO::collateMatrixFields(uint32_t, uint32_t, vector<char>
         case MAT_UINT32_CLASS:    variable = constructMatrix<int32_t>(name, dims, real, imag, real_type); break;
         case MAT_FLOAT_CLASS:     variable = constructMatrix<float>(name, dims, real, imag, real_type); break;
         case MAT_DOUBLE_CLASS:    variable = constructMatrix<double>(name, dims, real, imag, real_type); break;
-        case MAT_INT64_CLASS:     variable = constructMatrix<int64_t>(name, dims, real, imag, real_type); break;
-        case MAT_UINT64_CLASS:    variable = constructMatrix<uint64_t>(name, dims, real, imag, real_type); break;
+        case MAT_INT64_CLASS:
+#if CVMATIO_HAS_OPENCV_INT64
+            variable = constructMatrix<int64_t>(name, dims, real, imag, real_type);
+#else
+            CV_Assert(false);
+#endif
+            break;
+        case MAT_UINT64_CLASS:
+#if CVMATIO_HAS_OPENCV_INT64
+            variable = constructMatrix<uint64_t>(name, dims, real, imag, real_type);
+#else
+            CV_Assert(false);
+#endif
+            break;
         case MAT_CHAR_CLASS:      variable = constructString(name, dims, real); break;
         // sparse types
         case MAT_SPARSE_CLASS:    variable = constructSparse(name, dims, real, imag); break;


### PR DESCRIPTION
* bump CMake version to 1.0.28
* bump internal hunter to v0.19.161
* add preprocessor checks to prevent serialization of int64_t and uint64_t cv::Mat() objects
```
/.hunter/_Base/9af482b/ddb1453/8cbb54d/Install/include/opencv2/core/mat.inl.hpp:562:42: error: incomplete definition of type 'cv::traits::Type<unsigned long long>'
    : flags(MAGIC_VAL | traits::Type<_Tp>::value | CV_MAT_CONT_FLAG), dims(2), rows((int)vec.size()),
                        ~~~~~~~~~~~~~~~~~^~
/hunter-packages/cvmatio/src/MatlabIO.cpp:463:9: note: in instantiation of function template specialization 'cv::Mat::Mat<unsigned long long>' requested here
        flat = Mat(vec_real, true);
               ^
/hunter-packages/cvmatio/src/MatlabIO.cpp:582:24: note: in instantiation of function template specialization 'MatlabIO::constructMatrix<unsigned long long>' requested here
            variable = constructMatrix<uint64_t>(name, dims, real, imag, real_type);
```